### PR TITLE
use miniUI

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,11 +9,10 @@ Description: Knit an R Markdown file and post the result Markdown file to
 License: MIT + file LICENSE
 Imports:
   rmarkdown,
-  rstudioapi
-Remotes:
-  yutannihilation/qiitr,
-  rstudio/shiny,
-  rstudio/htmltools,
-  rstudio/shinygadgets
+  rstudioapi,
+  qiitr,
+  shiny,
+  htmltools,
+  miniUI
 LazyData: TRUE
-RoxygenNote: 5.0.1
+RoxygenNote: 6.0.1

--- a/R/qiitaddin.r
+++ b/R/qiitaddin.r
@@ -20,9 +20,9 @@ qiitaddin_knit <- function() {
   body <- paste(readLines(output_file, encoding = "UTF-8"), collapse = "\n")
 
   # Shiny UI -----------------------------------------------------------
-  ui <- shinygadgets::gadgetPage(
-    shinygadgets::titlebar("Preview"),
-    shinygadgets::contentPanel(
+  ui <- miniUI::miniPage(
+    miniUI::gadgetTitleBar("Preview"),
+    miniUI::miniContentPanel(
       shiny::div(shiny::includeMarkdown(output_file))
     )
   )
@@ -39,9 +39,9 @@ qiitaddin_knit <- function() {
 
       result <- qiitr::qiita_post_item(
         title = front_matter$title,
-        body = body,        
+        body = body,
         tags = lapply(front_matter$tags, qiitr::qiita_util_tag),
-        coediting = FALSE,        
+        coediting = FALSE,
         private   = TRUE,
         gist      = FALSE,
         tweet     = FALSE
@@ -52,6 +52,6 @@ qiitaddin_knit <- function() {
     })
   }
 
-  viewer <- shinygadgets::dialogViewer("Preview", width = 1000, height = 800)
-  shinygadgets::runGadget(ui, server, viewer = viewer)
+  viewer <- shiny::dialogViewer("Preview", width = 1000, height = 800)
+  shiny::runGadget(ui, server, viewer = viewer)
 }

--- a/man/qiitaddin.Rd
+++ b/man/qiitaddin.Rd
@@ -8,4 +8,3 @@
 \description{
 Knit an R Markdown file and post the result Markdown file to Qiita
 }
-

--- a/man/qiitaddin_knit.Rd
+++ b/man/qiitaddin_knit.Rd
@@ -9,4 +9,3 @@ qiitaddin_knit()
 \description{
 Knit the active document and display it
 }
-


### PR DESCRIPTION
qiitaddin currently uses [shinygadgets](https://github.com/rstudio/shinygadgets) package, which is unlikely to be released on CRAN.

As [the official document](https://rstudio.github.io/rstudioaddins/#shiny-gadgets) uses [miniUI](https://cran.r-project.org/package=miniUI), I should use this instead.